### PR TITLE
ci: added dmg and renamed package files

### DIFF
--- a/ci/linux/package-ubuntu.sh
+++ b/ci/linux/package-ubuntu.sh
@@ -5,12 +5,7 @@ set -e
 script_dir=$(dirname "$0")
 source "$script_dir/../ci_includes.generated.sh"
 
-export GIT_HASH=$(git rev-parse --short HEAD)
-export PKG_VERSION="1-$GIT_HASH-$BRANCH_SHORT_NAME-git"
-
-if [[ "$BRANCH_FULL_NAME" =~ "^refs/tags/" ]]; then
-	export PKG_VERSION="$BRANCH_SHORT_NAME"
-fi
+export PKG_VERSION="1-$(git describe --tags --long --always)"
 
 cd ./build
 

--- a/ci/macos/package-dmg.json.template
+++ b/ci/macos/package-dmg.json.template
@@ -1,0 +1,25 @@
+{
+    "title": "%PLUGIN_NAME% %VERSION%",
+    "format": "ULFO",
+    "window": {
+        "position": {
+            "x": 100,
+            "y": 100
+        },
+        "size": {
+            "width": 540,
+            "height": 380
+        }
+    },
+    "contents": [{
+        "x": 124,
+        "y": 180,
+        "type": "file",
+        "path": "%PLUGIN_ROOT%"
+    }, {
+        "x": 416,
+        "y": 180,
+        "type": "link",
+        "path": "/Library/Application Support/obs-studio/plugins"
+    }]
+}

--- a/ci/windows/package-windows.cmd
+++ b/ci/windows/package-windows.cmd
@@ -3,7 +3,7 @@ call "%~dp0..\ci_includes.generated.cmd"
 mkdir package
 cd package
 
-git rev-parse --short HEAD > package-version.txt
+git describe --tags --long --always > package-version.txt
 set /p PackageVersion=<package-version.txt
 del package-version.txt
 


### PR DESCRIPTION
- Added dmg package for macos.
- All packages has same naming `${PLUGIN_NAME}-$(git describe --tags --long)-${OS}` so that later scripting becomes easy.